### PR TITLE
Use service context to start capture request activity

### DIFF
--- a/app/src/main/java/com/chiller3/mirrormobile/mirror/DisplayScreen.kt
+++ b/app/src/main/java/com/chiller3/mirrormobile/mirror/DisplayScreen.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2024-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -35,7 +35,8 @@ import com.chiller3.mirrormobile.Permissions
 import com.chiller3.mirrormobile.Preferences
 import com.chiller3.mirrormobile.R
 
-class DisplayScreen(carContext: CarContext) : Screen(carContext), DefaultLifecycleObserver,
+class DisplayScreen(carContext: CarContext, private val activityLaunchContext: Context) :
+    Screen(carContext), DefaultLifecycleObserver,
     SharedPreferences.OnSharedPreferenceChangeListener, ServiceConnection, CaptureService.Listener,
     SurfaceCallback, OnCarDataAvailableListener<Speed> {
     companion object {
@@ -219,7 +220,7 @@ class DisplayScreen(carContext: CarContext) : Screen(carContext), DefaultLifecyc
         Log.d(TAG, "Capture is ready")
 
         state.getTransitionOrNull(DisplayState.StartMirroring::class.java)
-            ?.tryStartMirroring(carContext, prefs.autoStart)
+            ?.tryStartMirroring(activityLaunchContext, prefs.autoStart)
             ?.let { state = it }
     }
 
@@ -286,7 +287,7 @@ class DisplayScreen(carContext: CarContext) : Screen(carContext), DefaultLifecyc
         Log.d(TAG, "Start button pressed")
 
         state = state.getTransition(DisplayState.StartMirroring::class.java)
-            .tryStartMirroring(carContext, true)
+            .tryStartMirroring(activityLaunchContext, true)
     }
 
     private fun onStopPressed() {

--- a/app/src/main/java/com/chiller3/mirrormobile/mirror/DisplayService.kt
+++ b/app/src/main/java/com/chiller3/mirrormobile/mirror/DisplayService.kt
@@ -37,6 +37,7 @@ class DisplayService : CarAppService() {
     }
 
     override fun onCreateSession(): Session = object : Session() {
-        override fun onCreateScreen(intent: Intent): Screen = DisplayScreen(carContext)
+        override fun onCreateScreen(intent: Intent): Screen =
+            DisplayScreen(carContext, this@DisplayService)
     }
 }

--- a/app/src/main/java/com/chiller3/mirrormobile/mirror/DisplayState.kt
+++ b/app/src/main/java/com/chiller3/mirrormobile/mirror/DisplayState.kt
@@ -1,10 +1,11 @@
 /*
- * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2024-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
 package com.chiller3.mirrormobile.mirror
 
+import android.content.Context
 import android.content.Intent
 import android.util.Log
 import androidx.car.app.CarContext
@@ -147,7 +148,7 @@ sealed interface DisplayState {
 
         fun toStartedRequest(): DisplayState
 
-        fun tryStartMirroring(carContext: CarContext, canRequest: Boolean): DisplayState {
+        fun tryStartMirroring(activityLaunchContext: Context, canRequest: Boolean): DisplayState {
             if (captureBinder.haveCaptureSession()) {
                 Log.d(TAG, "Attaching to capture session")
 
@@ -162,8 +163,8 @@ sealed interface DisplayState {
             } else if (canRequest) {
                 Log.d(TAG, "Starting capture permission request")
 
-                carContext.startActivity(
-                    Intent(carContext, CaptureRequestActivity::class.java).apply {
+                activityLaunchContext.startActivity(
+                    Intent(activityLaunchContext, CaptureRequestActivity::class.java).apply {
                         flags = Intent.FLAG_ACTIVITY_NEW_TASK
                     }
                 )


### PR DESCRIPTION
It seems that using the CarContext to start an activity no longer works and will fail with:

    FATAL EXCEPTION: main
    Process: com.chiller3.mirrormobile, PID: 9305
    java.lang.RuntimeException: java.lang.SecurityException: Permission Denial: starting Intent { flg=0x10000000 cmp=com.chiller3.mirrormobile/.mirror.CaptureRequestActivity } from ProcessRecord{669e980 9305:com.chiller3.mirrormobile/u0a16} (pid=9305, uid=10016) with launchDisplayId=24
          at androidx.car.app.utils.RemoteUtils$$ExternalSyntheticLambda2.run(Unknown Source:141)
          at android.os.Handler.handleCallback(Handler.java:991)
          at android.os.Handler.dispatchMessage(Handler.java:102)
          at android.os.Looper.loopOnce(Looper.java:232)
          at android.os.Looper.loop(Looper.java:317)
          at android.app.ActivityThread.main(ActivityThread.java:8973)
          at java.lang.reflect.Method.invoke(Native Method)
          at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:591)
          at com.android.internal.os.ExecInit.main(ExecInit.java:50)
          at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)
          at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:369)
    Caused by: java.lang.SecurityException: Permission Denial: starting Intent { flg=0x10000000 cmp=com.chiller3.mirrormobile/.mirror.CaptureRequestActivity } from ProcessRecord{669e980 9305:com.chiller3.mirrormobile/u0a16} (pid=9305, uid=10016) with launchDisplayId=24
          at android.os.Parcel.createExceptionOrNull(Parcel.java:3270)
          at android.os.Parcel.createException(Parcel.java:3254)
          at android.os.Parcel.readException(Parcel.java:3230)
          at android.os.Parcel.readException(Parcel.java:3172)
          at android.app.IActivityTaskManager$Stub$Proxy.startActivity(IActivityTaskManager.java:2119)
          at android.app.Instrumentation.execStartActivity(Instrumentation.java:2016)
          at android.app.ContextImpl.startActivity(ContextImpl.java:1172)
          at android.app.ContextImpl.startActivity(ContextImpl.java:1143)
          at android.content.ContextWrapper.startActivity(ContextWrapper.java:438)
          at androidx.tracing.Trace.tryStartMirroring(Unknown Source:127)
          at com.chiller3.mirrormobile.mirror.DisplayState$Inactive.tryStartMirroring(Unknown Source:0)
          at androidx.activity.OnBackPressedDispatcher$addCallback$1.invoke(Unknown Source:71)
          at com.chiller3.mirrormobile.mirror.DisplayScreen$$ExternalSyntheticLambda2.onClick(Unknown Source:40)
          at androidx.car.app.model.OnClickDelegateImpl$OnClickListenerStub.lambda$onClick$0(Unknown Source:2)
          at androidx.car.app.model.OnClickDelegateImpl$OnClickListenerStub.$r8$lambda$XNCP4ktZ0-uqZhJZBLJ1aOuuP5k(Unknown Source:0)
          at androidx.car.app.model.OnClickDelegateImpl$OnClickListenerStub$$ExternalSyntheticLambda0.dispatch(Unknown Source:23)
          at androidx.car.app.utils.RemoteUtils$$ExternalSyntheticLambda2.run(Unknown Source:120)
          ... 10 more
    Caused by: android.os.RemoteException: Remote stack trace:
          at com.android.server.wm.SafeActivityOptions.checkPermissions(SafeActivityOptions.java:295)
          at com.android.server.wm.SafeActivityOptions.getOptions(SafeActivityOptions.java:172)
          at com.android.server.wm.ActivityStarter.executeRequest(ActivityStarter.java:1295)
          at com.android.server.wm.ActivityStarter.execute(ActivityStarter.java:864)
          at com.android.server.wm.ActivityTaskManagerService.startActivityAsUser(ActivityTaskManagerService.java:1321)

There is an upstream bug report for this that mentions this behavior changed with Android 15, though MirrorMobile originally worked fine on Android 15. Perhaps an Android Auto update was also necessary to trigger the issue. In any case, we can work around the problem by using the Service context instead of the CarContext when launching activities.

Upstream: https://issuetracker.google.com/issues/372055514