### PR TITLE
DisplayState: Set launch display ID when starting CaptureRequestActivity

### DIFF
--- a/app/src/main/java/com/chiller3/mirrormobile/mirror/DisplayScreen.kt
+++ b/app/src/main/java/com/chiller3/mirrormobile/mirror/DisplayScreen.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024-2025 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -35,8 +35,7 @@ import com.chiller3.mirrormobile.Permissions
 import com.chiller3.mirrormobile.Preferences
 import com.chiller3.mirrormobile.R
 
-class DisplayScreen(carContext: CarContext, private val activityLaunchContext: Context) :
-    Screen(carContext), DefaultLifecycleObserver,
+class DisplayScreen(carContext: CarContext) : Screen(carContext), DefaultLifecycleObserver,
     SharedPreferences.OnSharedPreferenceChangeListener, ServiceConnection, CaptureService.Listener,
     SurfaceCallback, OnCarDataAvailableListener<Speed> {
     companion object {
@@ -220,7 +219,7 @@ class DisplayScreen(carContext: CarContext, private val activityLaunchContext: C
         Log.d(TAG, "Capture is ready")
 
         state.getTransitionOrNull(DisplayState.StartMirroring::class.java)
-            ?.tryStartMirroring(activityLaunchContext, prefs.autoStart)
+            ?.tryStartMirroring(carContext, prefs.autoStart)
             ?.let { state = it }
     }
 
@@ -287,7 +286,7 @@ class DisplayScreen(carContext: CarContext, private val activityLaunchContext: C
         Log.d(TAG, "Start button pressed")
 
         state = state.getTransition(DisplayState.StartMirroring::class.java)
-            .tryStartMirroring(activityLaunchContext, true)
+            .tryStartMirroring(carContext, true)
     }
 
     private fun onStopPressed() {

--- a/app/src/main/java/com/chiller3/mirrormobile/mirror/DisplayService.kt
+++ b/app/src/main/java/com/chiller3/mirrormobile/mirror/DisplayService.kt
@@ -37,7 +37,6 @@ class DisplayService : CarAppService() {
     }
 
     override fun onCreateSession(): Session = object : Session() {
-        override fun onCreateScreen(intent: Intent): Screen =
-            DisplayScreen(carContext, this@DisplayService)
+        override fun onCreateScreen(intent: Intent): Screen = DisplayScreen(carContext)
     }
 }

--- a/app/src/main/java/com/chiller3/mirrormobile/mirror/DisplayState.kt
+++ b/app/src/main/java/com/chiller3/mirrormobile/mirror/DisplayState.kt
@@ -1,11 +1,10 @@
 /*
- * SPDX-FileCopyrightText: 2024-2025 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
 package com.chiller3.mirrormobile.mirror
 
-import android.content.Context
 import android.content.Intent
 import android.util.Log
 import androidx.car.app.CarContext
@@ -148,7 +147,7 @@ sealed interface DisplayState {
 
         fun toStartedRequest(): DisplayState
 
-        fun tryStartMirroring(activityLaunchContext: Context, canRequest: Boolean): DisplayState {
+        fun tryStartMirroring(carContext: CarContext, canRequest: Boolean): DisplayState {
             if (captureBinder.haveCaptureSession()) {
                 Log.d(TAG, "Attaching to capture session")
 
@@ -163,8 +162,8 @@ sealed interface DisplayState {
             } else if (canRequest) {
                 Log.d(TAG, "Starting capture permission request")
 
-                activityLaunchContext.startActivity(
-                    Intent(activityLaunchContext, CaptureRequestActivity::class.java).apply {
+                carContext.startActivity(
+                    Intent(carContext, CaptureRequestActivity::class.java).apply {
                         flags = Intent.FLAG_ACTIVITY_NEW_TASK
                     }
                 )

--- a/app/src/main/java/com/chiller3/mirrormobile/mirror/DisplayState.kt
+++ b/app/src/main/java/com/chiller3/mirrormobile/mirror/DisplayState.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Andrew Gunnerson
+ * SPDX-FileCopyrightText: 2024-2025 Andrew Gunnerson
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
@@ -7,8 +7,10 @@ package com.chiller3.mirrormobile.mirror
 
 import android.content.Intent
 import android.util.Log
+import android.view.Display
 import androidx.car.app.CarContext
 import androidx.car.app.SurfaceContainer
+import androidx.core.app.ActivityOptionsCompat
 
 /**
  * This implements a state machine for [DisplayScreen] to clearly express what the valid states are,
@@ -165,7 +167,11 @@ sealed interface DisplayState {
                 carContext.startActivity(
                     Intent(carContext, CaptureRequestActivity::class.java).apply {
                         flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                    }
+                    },
+                    ActivityOptionsCompat
+                        .makeBasic()
+                        .setLaunchDisplayId(Display.DEFAULT_DISPLAY)
+                        .toBundle(),
                 )
 
                 return toStartedRequest()


### PR DESCRIPTION
This properly fixes the launching of host device activities from a `CarContext`.