### PR TITLE
Remove Google Play dependency info block

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -164,6 +164,10 @@ android {
         buildConfig = true
         viewBinding = true
     }
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
This metadata is encrypted with Google's public key and is unreadable by anyone else. We have no need for this.